### PR TITLE
Install libsdl2 to surpress SDL warnings

### DIFF
--- a/build_dedicated_valheim_server.sh
+++ b/build_dedicated_valheim_server.sh
@@ -42,8 +42,8 @@ tput setaf 9;
 sleep 1
 
 #install steamcmd
-tput setaf 1; echo "Installing steamcmd"
-apt install steamcmd -y
+tput setaf 1; echo "Installing steamcmd and libsdl2"
+apt install steamcmd libsdl2-2.0-0 libsdl2-2.0-0:i386 -y
 tput setaf 2; echo "Done"
 tput setaf 9;
 sleep 1


### PR DESCRIPTION
Fixes #31

We need system default and `i386` architectures of `libsdl2-2.0-0` since the valheim server and steamcmd both use different architectures