### PR TITLE
Install software-properties-common

### DIFF
--- a/build_dedicated_valheim_server.sh
+++ b/build_dedicated_valheim_server.sh
@@ -20,6 +20,13 @@ tput setaf 2; echo "Done"
 tput setaf 9;
 sleep 1
 
+#install software-properties-common for add-apt-repository command below
+tput setaf 2; echo "Installing software-properties-common package"
+apt install software-properties-common
+tput setaf 2; echo "Done"
+tput setaf 9;
+sleep 1
+
 #add multiverse repo
 tput setaf 2; echo "Adding multiverse REPO"
 add-apt-repository -y multiverse


### PR DESCRIPTION
The `add-apt-repository` command depends on the `software-properties-common` packing being installed.