### PR TITLE
fix unary operator expected error when comparing versions prior to update

### DIFF
--- a/menu.sh
+++ b/menu.sh
@@ -617,7 +617,7 @@ function check_apply_server_updates_beta() {
       sed -e 's/[\t ]//g;/^$/d' /home/steam/valheimserver/steamapps/appmanifest_896660.acf > appmani.log
       localValheim=$(sed -n '11p' appmani.log)
       echo "Local Valheim Ver: $localValheim"
-      if [ $repoValheim == $localValheim ]; then
+      if [ "$repoValheim" == "$localValheim" ]; then
         echo "No new Updates found"
 	sleep 2
 	else


### PR DESCRIPTION
Currently there's an error here because the values of `$repoValheim` and `$localValheim` contain two sets quotes, which bash is interpreting as two different parameters to the `[` command.  Quoting around these variables ensures bash treats the entire value as a single parameter to `[`.