### PR TITLE
Fix error in backup filename creation

### DIFF
--- a/menu.sh
+++ b/menu.sh
@@ -476,7 +476,7 @@ function backup_world_data() {
     echo ""
     echo ""
          ## Get the current date as variable.
-         TODAY="$(date +%Y-%m-%d-%X)"
+         TODAY="$(date +%Y-%m-%d-%T)"
 	 echo "Checking to see if backup directory is created"
 	 echo "If not, one will be created"
 	 dldir=$backupPath


### PR DESCRIPTION
Fixes #82 by using 24 hour time format instead using the format from the users locale.