### PR TITLE
libc6-dev needed for plugin support (bepinex)

### DIFF
--- a/menu.sh
+++ b/menu.sh
@@ -351,7 +351,7 @@ sleep 5
 tput setaf 1; echo "Installing steamcmd and libsdl2" ; tput setaf 9;
 echo steam steam/question select "I AGREE" | sudo debconf-set-selections
 echo steam steam/license note '' | sudo debconf-set-selections
-apt install steamcmd libsdl2-2.0-0 libsdl2-2.0-0:i386 -y
+apt install steamcmd libsdl2-2.0-0 libsdl2-2.0-0:i386 libc6-dev -y
 tput setaf 2; echo "Done" ; tput setaf 9;
 sleep 1
 


### PR DESCRIPTION
Useful if we want to run any plugin like Valehim+ or similar.