### PR TITLE
Grep all syslogs when checking for player connection history

### DIFF
--- a/menu.sh
+++ b/menu.sh
@@ -913,7 +913,7 @@ clear
 function display_player_history() {
 clear
     echo ""
-    sudo cat /var/log/syslog | grep ZDOID
+    sudo grep ZDOID /var/log/syslog*
     echo ""
 
 }


### PR DESCRIPTION
When syslogs rotate, the script effectively loses player connection history. This PR simply checks all of the syslogs with a glob

Fixes #110