### PR TITLE
Add language selection

### DIFF
--- a/advancemenu.sh
+++ b/advancemenu.sh
@@ -9,8 +9,12 @@
 
 
 #Current Options: DE= German, EN=English, FR=French, SP=Spanish"
-
-LANGUAGE=EN
+if [ "$1" == "" ]
+then
+        LANGUAGE=EN
+else
+        LANGUAGE=DE
+fi
 source lang/$LANGUAGE.conf
 
 

--- a/menu.sh
+++ b/menu.sh
@@ -9,8 +9,12 @@
 
 
 #Current Options: DE=German, EN=English, FR=French, SP=Spanish"
-
-LANGUAGE=EN
+if [ "$1" == "" ]
+then
+        LANGUAGE=EN
+else
+        LANGUAGE=DE
+fi
 source lang/$LANGUAGE.conf
 
 


### PR DESCRIPTION
This time for beta branch :)

Adds language selection through a command line argument (EN, DE, FR, SP) to both menu scripts.
By starting with ./menu DE you'd get the german language script.

Defaults to EN language with no argument.

More of a quick-and-dirty approach but this way you don't have to edit the scripts.