### PR TITLE
Fix language select

### DIFF
--- a/advancemenu.sh
+++ b/advancemenu.sh
@@ -13,7 +13,7 @@ if [ "$1" == "" ]
 then
         LANGUAGE=EN
 else
-        LANGUAGE=DE
+        LANGUAGE=$1
 fi
 source lang/$LANGUAGE.conf
 

--- a/menu.sh
+++ b/menu.sh
@@ -13,7 +13,7 @@ if [ "$1" == "" ]
 then
         LANGUAGE=EN
 else
-        LANGUAGE=DE
+        LANGUAGE=$1
 fi
 source lang/$LANGUAGE.conf
 


### PR DESCRIPTION
Missed the actual language selection argument.
Instead it ran the German language menu for all inputs - it will now read the first argument after ./menu and actually apply the language