### PR TITLE
localization config typo fixes

### DIFF
--- a/advancemenu.sh
+++ b/advancemenu.sh
@@ -283,7 +283,7 @@ echo ""
     tput setaf 1; echo "$PUBLIC_ENABLED_DISABLE_INFO" ; tput setaf 9;
     tput setaf 2; echo "$DRAW60" ; tput setaf 9;
     tput setaf 2; echo "$PUBLIC_ENABLED_DISABLE_EXAMPLE_SHOW" ; tput setaf 9;
-    tput setaf 1; echo "$PUBLIC_ENABLED_DISABLE_EXAMPLS_LAN_NO_SHOW" ; tput setaf 9;
+    tput setaf 1; echo "$PUBLIC_ENABLED_DISABLE_EXAMPLE_LAN_NO_SHOW" ; tput setaf 9;
     tput setaf 2; echo "$DRAW60" ; tput setaf 9;
     echo ""
       read -p "$PUBLIC_ENABLED_DISABLE_INPUT" publicList

--- a/lang/DA.conf
+++ b/lang/DA.conf
@@ -1,6 +1,6 @@
 #Start Danish Configuration File
 
-#Mulitpule reused echos
+#Multiple reused echos
 
 DRAW60="------------------------------------------------------------"
 DRAW80="--------------------------------------------------------------------------------"
@@ -55,7 +55,7 @@ ADD_MULTIVERSE="Adding multiverse REPO"
 #line 171
 ADD_I386="Adding i386 architecture"
 
-#177
+#line 177
 CHECK_FOR_UPDATES_AGAIN="Checking and updating system again"
 
 #line 185
@@ -75,7 +75,7 @@ STEAM_PASS_MUST_BE="Password must be 6 Characters or more"
 STEAM_PASS_MUST_BE_1="At least one number, one uppercase letter and one lowercase letter"
 STEAM_GOOD_EXAMPLE="Good Example: Viking12"
 STEAM_BAD_EXAMPLE="Bad Example: Vik!"
-STEAM_PLEASE_ENTER_STEAM_PASSWORD="Please enter a password for the steam local user: " 
+STEAM_PLEASE_ENTER_STEAM_PASSWORD="Please enter a password for the steam local user: "
 STEAM_PASS_NOT_ACCEPTED="Password not accepted - Too Short or has Special Characters"
 STEAM_PASS_NOT_ACCEPTED_1="I swear to LOKI, you better NOT use Special Characters"
 
@@ -96,7 +96,7 @@ WORLD_SET_CHAR_RULES="Name must be 4 Characters or more"
 WORLD_SET_NO_SPECIAL_CHAR_RULES="No Special Characters not even a space"
 WORLD_GOOD_EXAMPLE="Good Example: ThorsHammer"
 WORLD_BAD_EXAMPLE="Bad Example: Loki is a Trickster"
-WORLD_SET_WORLD_NAME_VAR="Please set the world name: " 
+WORLD_SET_WORLD_NAME_VAR="Please set the world name: "
 WORLD_SET_ERROR="World Name not set: Too Short or has Special Characters"
 WORLD_SET_ERROR_1="I swear to LOKI, you better NOT use Special Characters"
 
@@ -123,7 +123,7 @@ SERVER_ACCESS_PASSWORD_ERROR_1="I swear to LOKI, you better NOT use Special Char
 PUBLIC_ENABLED_DISABLE_HEADER="---------------------Public Server Shown--------------------"
 PUBLIC_ENABLED_DISABLE_INFO="Do you want your Server Shown Publicly"
 PUBLIC_ENABLED_DISABLE_EXAMPLE_SHOW="Show Server in Public List: 1 "
-PUBLIC_ENABLED_DISABLE_EXAMPLS_LAN_NO_SHOW="Play Server on LAN or Not Listed Publicly: 0"
+PUBLIC_ENABLED_DISABLE_EXAMPLE_LAN_NO_SHOW="Play Server on LAN or Not Listed Publicly: 0"
 PUBLIC_ENABLED_DISABLE_INPUT="Set Public to 1 or 0: "
 
 #line 281-309
@@ -169,7 +169,7 @@ INSTALL_BUILD_ENABLE_VALHEIM_SERVICE="Enabling Valheim Server on start or after 
 #line 424-243
 INSTALL_BUILD_FINISH_THANK_YOU="Check server status by typing systemctl status valheimserver.service
 Thank you for using the script.
-AND A HUGE THANKS TO github: @Lachlanmac, @JamieeLee, @RedKrieg, @bherbruck 
+AND A HUGE THANKS TO github: @Lachlanmac, @JamieeLee, @RedKrieg, @bherbruck
 @xaviablaza, @joaoanes, @amasover, @madmozg, @nicolas-martin, @devdavi and others!
 If your name is missing! Let me know!
 -ZeroBandwidth
@@ -336,7 +336,7 @@ FUNCTION_WRITE_CONFIG_RESTART_SERVICE_INFO="Restarting Valheim Server Service"
 FUNCTION_CHANGE_PUBLIC_DISPLAY_NAME_HEADER="------------------Set New Public Display Name---------------"
 FUNCTION_CHANGE_PUBLIC_DISPLAY_NAME_INFO="Now for Loki, please follow instructions"
 FUNCTION_CHANGE_PUBLIC_DISPLAY_NAME_INFO_1="The Server is required to have a public display name"
-FUNCTION_CHANGE_PUBLIC_DISPLAY_NAME_INFO_2="The Only SPECIAL characters allowed are: spaces, brackets and apostrophes " 
+FUNCTION_CHANGE_PUBLIC_DISPLAY_NAME_INFO_2="The Only SPECIAL characters allowed are: spaces, brackets and apostrophes "
 FUNCTION_CHANGE_PUBLIC_DISPLAY_CURRENT_NAME="Current Public Display Name: "
 FUNCTION_CHANGE_PUBLIC_DISPLAY_EDIT_NAME_INFO="Enter new public server display name: "
 FUNCTION_CHANGE_PUBLIC_DISPLAY_OLD_PUBLIC_NAME="Old Public Display Name: "
@@ -349,9 +349,9 @@ FUNCTION_CHANGE_DEFAULT_SERVER_PORT_HEADER="---------------------Set New Server 
 FUNCTION_CHANGE_DEFAULT_SERVER_PORT_INFO="Now for Loki, please follow instructions"
 FUNCTION_CHANGE_DEFAULT_SERVER_PORT_INFO_1="The Server is required to have a port to operate on"
 FUNCTION_CHANGE_DEFAULT_SERVER_PORT_INFO_2="Do not use SPECIAL characters:"
-FUNCTION_CHANGE_DEFAULT_SERVER_PORT_INFO_3="New assigned port must be greater than 1024:" 
+FUNCTION_CHANGE_DEFAULT_SERVER_PORT_INFO_3="New assigned port must be greater than 1024:"
 FUNCTION_CHANGE_DEFAULT_SERVER_PORT_CURRENT="Current Server Port: "
-FUNCTION_CHANGE_DEFAULT_SERVER_PORT_EDIT_PORT="Enter new Server Port (Default:2456): " 
+FUNCTION_CHANGE_DEFAULT_SERVER_PORT_EDIT_PORT="Enter new Server Port (Default:2456): "
 FUNCTION_CHANGE_DEFAULT_SERVER_PORT_ERROR_CHECK_MSG="Try again, Loki got you or you typed something wrong or your port range is incorrect"
 FUNCTION_CHANGE_DEFAULT_SERVER_PORT_OLD_PORT="Old Server Port: "
 FUNCTION_CHANGE_DEFAULT_SERVER_PORT_NEW_PORT="New Server Port: "
@@ -370,20 +370,20 @@ Don't you have some bees to go check on? "
                                         #DRAW "------------------------------------------------------------"
 FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_HEADER="---------------Set New Server Access Password---------------"
 FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_INFO="Now for Loki, please follow instructions"
-FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_INFO_1="Valheim requires a UNIQUE password 6 characaters or longer"
+FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_INFO_1="Valheim requires a UNIQUE password 6 characters or longer"
 FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_INFO_2="UNIQUE means Password can not match Public and World Names"
 FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_INFO_3="Do not use SPECIAL characters:"
 FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_CURRENT_DISPLAY_NAME="Current Public Display Name:"
 FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_CURRENT_WORLD_NAME="Current World Name:"
 FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_CURRENT_PASS="Current Access Password: "
-FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_INFO_RULES="This password must be 5 Characters or more" 
+FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_INFO_RULES="This password must be 5 Characters or more"
 FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_INFO_RULES_1="At least one number, one uppercase letter and one lowercase letter"
 FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_GOOD="Good Example: Viking12"
 FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_BAD="Bad Example: Vik!"
 FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_ENTER_NEW="Enter Password to Enter your Valheim Server: "
 FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_ERROR_MSG="Password not accepted - Too Short, Special Characters"
 FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_ERROR_MSG_1="I swear to LOKI, you better NOT use Special Characters"
-FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_OLD_PASS="Old Server Access Password:" 
+FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_OLD_PASS="Old Server Access Password:"
 FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_NEW_PASS="New Server Access Password:"
 FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_CANCEL="Canceled the renaming of Public Valheim Server Display Name - because Loki sucks"
 
@@ -396,7 +396,7 @@ FUNCTION_HEADER_MENU_INFO_VALHEIM_OFFICIAL_BUILD="Valheim Official Build:"
 FUNCTION_HEADER_MENU_INFO_VALHEIM_LOCAL_BUILD="Valheim Server Build:"
 FUNCTION_HEADER_MENU_INFO_SERVER_NAME="Server Name: "
 FUNCTION_HEADER_MENU_INFO_SERVER_PORT="Server Port:"
-FUNCTION_HEADER_MENU_INFO_PUBLIC_LIST="Public Listing:" 
+FUNCTION_HEADER_MENU_INFO_PUBLIC_LIST="Public Listing:"
 FUNCTION_HEADER_MENU_INFO_CURRENT_NJORD_RELEASE="Github Njord Release: "
 FUNCTION_HEADER_MENU_INFO_LOCAL_NJORD_VERSION="Installed Njord Menu: "
 FUNCTION_HEADER_MENU_INFO_GG_ZEROBANDWIDTH="Happy Gaming - ZeroBandwidth"
@@ -452,7 +452,7 @@ FUNCTION_VALHEIM_PLUS_INSTALL_LETS_GO="Let's GO!!!!"
 
 FUNCTION_VALHEIM_PLUS_ENABLE="Enabling Valheim+"
 FUNCTION_VALHEIM_PLUS_RESTARTING="Restarting Valheim Services, so changes can be applied"
-FUNCTION_VALHEIM_PLUS_ENABLED_ACTIVE="Valheim+ is now enabled and Active" 
+FUNCTION_VALHEIM_PLUS_ENABLED_ACTIVE="Valheim+ is now enabled and Active"
 
 FUNCTION_VALHEIM_PLUS_DISABLE="Valheim+ Disable"
 FUNCTION_VALHEIM_PLUS_DISABLE_RESTARTING="Restarting Valheim Services, so changes can be applied"
@@ -464,8 +464,8 @@ FUNCTION_VALHEIM_PLUS_UPDATE_UPDATE_FOUND="Update found!"
 FUNCTION_VALHEIM_PLUS_UPDATE_CONTINUE="Do you wish to continue?"
 FUNCTION_VALHEIM_PLUS_UPDATE_BACKING_UP_VPLUS_CONFIG="Making quick backup of valheim_plus.cfg"
 FUNCTION_VALHEIM_PLUS_UPDATE_DOWNLOADING_VPLUS="Grabbing Latest from Valheim Plus and Installing!"
-FUNCTION_VALHEIM_PLUS_UPDATE_RESTARTING_SERVICES="Restarting Services to apply updates" 
-FUNCTION_VALHEIM_PLUS_UPDATE_CANCELED="Canceled the upgrading of Valheim Plus - because Loki sucks" 
+FUNCTION_VALHEIM_PLUS_UPDATE_RESTARTING_SERVICES="Restarting Services to apply updates"
+FUNCTION_VALHEIM_PLUS_UPDATE_CANCELED="Canceled the upgrading of Valheim Plus - because Loki sucks"
 
 FUNCTION_VALHEIM_PLUS_EDIT_VPLUS_CONFIG_SAVE_RESTART="If you made changes, Valheim Services need to be restarted to take effect"
 FUNCTION_VALHEIM_PLUS_EDIT_VPLUS_CONFIG_SAVE_RESTART_1="Do you wish to restart Valheim Services now?"

--- a/lang/DE.conf
+++ b/lang/DE.conf
@@ -1,6 +1,6 @@
 #Start German Configuration File
 
-#Mulitpule reused echos
+#Multiple reused echos
 
 DRAW60="------------------------------------------------------------"
 DRAW80="--------------------------------------------------------------------------------"
@@ -55,7 +55,7 @@ ADD_MULTIVERSE="Füge multiverse REPO hinzu"
 #line 171
 ADD_I386="Füge i386 Architektur hinzu"
 
-#177
+#line 177
 CHECK_FOR_UPDATES_AGAIN="Suche erneut nach Updates"
 
 #line 185
@@ -123,7 +123,7 @@ SERVER_ACCESS_PASSWORD_ERROR_1="Ich schwöre bei LOKI, du benutzt besser KEINE S
 PUBLIC_ENABLED_DISABLE_HEADER="---------------------Public Server Anzeige--------------------"
 PUBLIC_ENABLED_DISABLE_INFO="Möchtest du deinen Server öffentlich anzeigen lassen"
 PUBLIC_ENABLED_DISABLE_EXAMPLE_SHOW="Zeige Server in öffentlicher Liste: 1 "
-PUBLIC_ENABLED_DISABLE_EXAMPLS_LAN_NO_SHOW="Spiele im lokalen Netzwerk oder ohne öffentliche Liste: 0"
+PUBLIC_ENABLED_DISABLE_EXAMPLE_LAN_NO_SHOW="Spiele im lokalen Netzwerk oder ohne öffentliche Liste: 0"
 PUBLIC_ENABLED_DISABLE_INPUT="Setze Öffentlich als 1 oder 0: "
 
 #line 281-309

--- a/lang/DU.conf
+++ b/lang/DU.conf
@@ -1,6 +1,6 @@
 #Start Dutch Configuration File
 
-#Mulitpule reused echos
+#Multiple reused echos
 
 DRAW60="------------------------------------------------------------"
 DRAW80="--------------------------------------------------------------------------------"
@@ -55,7 +55,7 @@ ADD_MULTIVERSE="Adding multiverse REPO"
 #line 171
 ADD_I386="Adding i386 architecture"
 
-#177
+#line 177
 CHECK_FOR_UPDATES_AGAIN="Checking and updating system again"
 
 #line 185
@@ -123,7 +123,7 @@ SERVER_ACCESS_PASSWORD_ERROR_1="I swear to LOKI, you better NOT use Special Char
 PUBLIC_ENABLED_DISABLE_HEADER="---------------------Public Server Shown--------------------"
 PUBLIC_ENABLED_DISABLE_INFO="Do you want your Server Shown Publicly"
 PUBLIC_ENABLED_DISABLE_EXAMPLE_SHOW="Show Server in Public List: 1 "
-PUBLIC_ENABLED_DISABLE_EXAMPLS_LAN_NO_SHOW="Play Server on LAN or Not Listed Publicly: 0"
+PUBLIC_ENABLED_DISABLE_EXAMPLE_LAN_NO_SHOW="Play Server on LAN or Not Listed Publicly: 0"
 PUBLIC_ENABLED_DISABLE_INPUT="Set Public to 1 or 0: "
 
 #line 281-309
@@ -370,7 +370,7 @@ Don't you have some bees to go check on? "
                                         #DRAW "------------------------------------------------------------"
 FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_HEADER="---------------Set New Server Access Password---------------"
 FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_INFO="Now for Loki, please follow instructions"
-FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_INFO_1="Valheim requires a UNIQUE password 6 characaters or longer"
+FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_INFO_1="Valheim requires a UNIQUE password 6 characters or longer"
 FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_INFO_2="UNIQUE means Password can not match Public and World Names"
 FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_INFO_3="Do not use SPECIAL characters:"
 FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_CURRENT_DISPLAY_NAME="Current Public Display Name:"

--- a/lang/EN.conf
+++ b/lang/EN.conf
@@ -1,6 +1,6 @@
 #Start English Configuration File
 
-#Mulitpule reused echos
+#Multiple reused echos
 
 DRAW60="------------------------------------------------------------"
 DRAW80="--------------------------------------------------------------------------------"
@@ -55,7 +55,7 @@ ADD_MULTIVERSE="Adding multiverse REPO"
 #line 171
 ADD_I386="Adding i386 architecture"
 
-#177
+#line 177
 CHECK_FOR_UPDATES_AGAIN="Checking and updating system again"
 
 #line 185
@@ -123,7 +123,7 @@ SERVER_ACCESS_PASSWORD_ERROR_1="I swear to LOKI, you better NOT use Special Char
 PUBLIC_ENABLED_DISABLE_HEADER="---------------------Public Server Shown--------------------"
 PUBLIC_ENABLED_DISABLE_INFO="Do you want your Server Shown Publicly"
 PUBLIC_ENABLED_DISABLE_EXAMPLE_SHOW="Show Server in Public List: 1 "
-PUBLIC_ENABLED_DISABLE_EXAMPLS_LAN_NO_SHOW="Play Server on LAN or Not Listed Publicly: 0"
+PUBLIC_ENABLED_DISABLE_EXAMPLE_LAN_NO_SHOW="Play Server on LAN or Not Listed Publicly: 0"
 PUBLIC_ENABLED_DISABLE_INPUT="Set Public to 1 or 0: "
 
 #line 281-309
@@ -370,7 +370,7 @@ Don't you have some bees to go check on? "
                                         #DRAW "------------------------------------------------------------"
 FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_HEADER="---------------Set New Server Access Password---------------"
 FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_INFO="Now for Loki, please follow instructions"
-FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_INFO_1="Valheim requires a UNIQUE password 6 characaters or longer"
+FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_INFO_1="Valheim requires a UNIQUE password 6 characters or longer"
 FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_INFO_2="UNIQUE means Password can not match Public and World Names"
 FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_INFO_3="Do not use SPECIAL characters:"
 FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_CURRENT_DISPLAY_NAME="Current Public Display Name:"

--- a/lang/FR.conf
+++ b/lang/FR.conf
@@ -1,7 +1,7 @@
 #Use this file to make your translations.
 #please keep the format as best as possible.
 
-#Mulitpule reused echos
+#Multiple reused echos
 
 DRAW60="------------------------------------------------------------"
 DRAW80="--------------------------------------------------------------------------------"
@@ -66,7 +66,7 @@ ADD_MULTIVERSE="Ajout des différents dépots"
 #line 171
 ADD_I386="Ajout de l'architecture i386"
 
-#177
+#line 177
 CHECK_FOR_UPDATES_AGAIN="Nouvelle vérification des MàJ système."
 
 #line 185
@@ -134,7 +134,7 @@ SERVER_ACCESS_PASSWORD_ERROR_1="Je jure sur LOKI, vous feriez mieux DE NE PAS ut
 PUBLIC_ENABLED_DISABLE_HEADER="------------------Lister le Serveur Public------------------"
 PUBLIC_ENABLED_DISABLE_INFO="Voulez-vous lsiter le serveur dans la liste des serveur public ?"
 PUBLIC_ENABLED_DISABLE_EXAMPLE_SHOW="Montrer le serveur dans la liste publique : 1 "
-PUBLIC_ENABLED_DISABLE_EXAMPLS_LAN_NO_SHOW="Jouer au serveur en réseau local ou en serveur non listé : 0"
+PUBLIC_ENABLED_DISABLE_EXAMPLE_LAN_NO_SHOW="Jouer au serveur en réseau local ou en serveur non listé : 0"
 PUBLIC_ENABLED_DISABLE_INPUT="Paramétrer le serveur sur 1 ou 0: "
 
 #line 281-309

--- a/lang/RO.conf
+++ b/lang/RO.conf
@@ -1,6 +1,6 @@
 #Start Romanian Configuration File
 
-#Mulitpule reused echos
+#Multiple reused echos
 
 DRAW60="------------------------------------------------------------"
 DRAW80="--------------------------------------------------------------------------------"
@@ -55,7 +55,7 @@ ADD_MULTIVERSE="Adding multiverse REPO"
 #line 171
 ADD_I386="Adding i386 architecture"
 
-#177
+#line 177
 CHECK_FOR_UPDATES_AGAIN="Checking and updating system again"
 
 #line 185
@@ -123,7 +123,7 @@ SERVER_ACCESS_PASSWORD_ERROR_1="I swear to LOKI, you better NOT use Special Char
 PUBLIC_ENABLED_DISABLE_HEADER="---------------------Public Server Shown--------------------"
 PUBLIC_ENABLED_DISABLE_INFO="Do you want your Server Shown Publicly"
 PUBLIC_ENABLED_DISABLE_EXAMPLE_SHOW="Show Server in Public List: 1 "
-PUBLIC_ENABLED_DISABLE_EXAMPLS_LAN_NO_SHOW="Play Server on LAN or Not Listed Publicly: 0"
+PUBLIC_ENABLED_DISABLE_EXAMPLE_LAN_NO_SHOW="Play Server on LAN or Not Listed Publicly: 0"
 PUBLIC_ENABLED_DISABLE_INPUT="Set Public to 1 or 0: "
 
 #line 281-309
@@ -370,7 +370,7 @@ Don't you have some bees to go check on? "
                                         #DRAW "------------------------------------------------------------"
 FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_HEADER="---------------Set New Server Access Password---------------"
 FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_INFO="Now for Loki, please follow instructions"
-FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_INFO_1="Valheim requires a UNIQUE password 6 characaters or longer"
+FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_INFO_1="Valheim requires a UNIQUE password 6 characters or longer"
 FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_INFO_2="UNIQUE means Password can not match Public and World Names"
 FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_INFO_3="Do not use SPECIAL characters:"
 FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_CURRENT_DISPLAY_NAME="Current Public Display Name:"

--- a/lang/RU.conf
+++ b/lang/RU.conf
@@ -1,6 +1,6 @@
 #Start Russian Configuration File
 
-#Mulitpule reused echos
+#Multiple reused echos
 
 DRAW60="------------------------------------------------------------"
 DRAW80="--------------------------------------------------------------------------------"
@@ -55,7 +55,7 @@ ADD_MULTIVERSE="Adding multiverse REPO"
 #line 171
 ADD_I386="Adding i386 architecture"
 
-#177
+#line 177
 CHECK_FOR_UPDATES_AGAIN="Checking and updating system again"
 
 #line 185
@@ -123,7 +123,7 @@ SERVER_ACCESS_PASSWORD_ERROR_1="I swear to LOKI, you better NOT use Special Char
 PUBLIC_ENABLED_DISABLE_HEADER="---------------------Public Server Shown--------------------"
 PUBLIC_ENABLED_DISABLE_INFO="Do you want your Server Shown Publicly"
 PUBLIC_ENABLED_DISABLE_EXAMPLE_SHOW="Show Server in Public List: 1 "
-PUBLIC_ENABLED_DISABLE_EXAMPLS_LAN_NO_SHOW="Play Server on LAN or Not Listed Publicly: 0"
+PUBLIC_ENABLED_DISABLE_EXAMPLE_LAN_NO_SHOW="Play Server on LAN or Not Listed Publicly: 0"
 PUBLIC_ENABLED_DISABLE_INPUT="Set Public to 1 or 0: "
 
 #line 281-309
@@ -370,7 +370,7 @@ Don't you have some bees to go check on? "
                                         #DRAW "------------------------------------------------------------"
 FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_HEADER="---------------Set New Server Access Password---------------"
 FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_INFO="Now for Loki, please follow instructions"
-FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_INFO_1="Valheim requires a UNIQUE password 6 characaters or longer"
+FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_INFO_1="Valheim requires a UNIQUE password 6 characters or longer"
 FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_INFO_2="UNIQUE means Password can not match Public and World Names"
 FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_INFO_3="Do not use SPECIAL characters:"
 FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_CURRENT_DISPLAY_NAME="Current Public Display Name:"

--- a/lang/SP.conf
+++ b/lang/SP.conf
@@ -1,6 +1,6 @@
 #Start Spanish Configuration File
 
-#Mulitpule reused echos
+#Multiple reused echos
 
 DRAW60="------------------------------------------------------------"
 DRAW80="--------------------------------------------------------------------------------"
@@ -81,7 +81,7 @@ ADD_MULTIVERSE="Añadiento el multiverso REPO"
 #ADD_I386="Adding i386 architecture"
 ADD_I386="Añadiendo arquitectura i386"
 
-#177
+#line 177
 #CHECK_FOR_UPDATES_AGAIN="Checking and updating system again"
 CHECK_FOR_UPDATES_AGAIN="Comprobando y actualizando el sistema de nuevo"
 
@@ -198,8 +198,8 @@ PUBLIC_ENABLED_DISABLE_HEADER="---------------Mostrar publicamente el Servidor--
 PUBLIC_ENABLED_DISABLE_INFO="¿Quieres mostrar tu servidor públicamente?"
 #PUBLIC_ENABLED_DISABLE_EXAMPLE_SHOW="Show Server in Public List: 1 "
 PUBLIC_ENABLED_DISABLE_EXAMPLE_SHOW="Mostrar servidor en lista publica: 1 "
-#PUBLIC_ENABLED_DISABLE_EXAMPLS_LAN_NO_SHOW="Play Server on LAN or Not Listed Publicly: 0"
-PUBLIC_ENABLED_DISABLE_EXAMPLS_LAN_NO_SHOW="Jugar al servidor en LAN o no mostrarlo publicamente: 0"
+#PUBLIC_ENABLED_DISABLE_EXAMPLE_LAN_NO_SHOW="Play Server on LAN or Not Listed Publicly: 0"
+PUBLIC_ENABLED_DISABLE_EXAMPLE_LAN_NO_SHOW="Jugar al servidor en LAN o no mostrarlo publicamente: 0"
 #PUBLIC_ENABLED_DISABLE_INPUT="Set Public to 1 or 0: "
 PUBLIC_ENABLED_DISABLE_INPUT="Establecer servidor como publico 1 o 0: "
 
@@ -629,7 +629,7 @@ Creo que mucha gente rompera sus servidores si añado esto ahora
 FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_HEADER="-----Establecer nueva contraseña de acceso del Servidor-----"
 #FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_INFO="Now for Loki, please follow instructions"
 FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_INFO="Ahora, por Loki, por favor sigue las instrucciones"
-#FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_INFO_1="Valheim requires a UNIQUE password 6 characaters or longer"
+#FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_INFO_1="Valheim requires a UNIQUE password 6 characters or longer"
 FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_INFO_1="Valheim necesita una contraseña UNICA de 6 caracteres o mas"
 #FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_INFO_2="UNIQUE means Password can not match Public and World Names"
 FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_INFO_2="UNICA significa que la contraseña no puede coincidir con el nombre publico y el nombre del Mundo"

--- a/lang/template.conf
+++ b/lang/template.conf
@@ -1,6 +1,6 @@
 #Start English Configuration File
 
-#Mulitpule reused echos
+#Multiple reused echos
 
 DRAW60="------------------------------------------------------------"
 DRAW80="--------------------------------------------------------------------------------"
@@ -59,7 +59,7 @@ ADD_MULTIVERSE="Adding multiverse REPO"
 #line 171
 ADD_I386="Adding i386 architecture"
 
-#177
+#line 177
 CHECK_FOR_UPDATES_AGAIN="Checking and updating system again"
 
 #line 185
@@ -79,7 +79,7 @@ STEAM_PASS_MUST_BE="Password must be 6 Characters or more"
 STEAM_PASS_MUST_BE_1="At least one number, one uppercase letter and one lowercase letter"
 STEAM_GOOD_EXAMPLE="Good Example: Viking12"
 STEAM_BAD_EXAMPLE="Bad Example: Vik!"
-STEAM_PLEASE_ENTER_STEAM_PASSWORD="Please enter a password for the steam local user: " 
+STEAM_PLEASE_ENTER_STEAM_PASSWORD="Please enter a password for the steam local user: "
 STEAM_PASS_NOT_ACCEPTED="Password not accepted - Too Short or has Special Characters"
 STEAM_PASS_NOT_ACCEPTED_1="I swear to LOKI, you better NOT use Special Characters"
 
@@ -100,7 +100,7 @@ WORLD_SET_CHAR_RULES="Name must be 4 Characters or more"
 WORLD_SET_NO_SPECIAL_CHAR_RULES="No Special Characters not even a space"
 WORLD_GOOD_EXAMPLE="Good Example: ThorsHammer"
 WORLD_BAD_EXAMPLE="Bad Example: Loki is a Trickster"
-WORLD_SET_WORLD_NAME_VAR="Please set the world name: " 
+WORLD_SET_WORLD_NAME_VAR="Please set the world name: "
 WORLD_SET_ERROR="World Name not set: Too Short or has Special Characters"
 WORLD_SET_ERROR_1="I swear to LOKI, you better NOT use Special Characters"
 
@@ -127,7 +127,7 @@ SERVER_ACCESS_PASSWORD_ERROR_1="I swear to LOKI, you better NOT use Special Char
 PUBLIC_ENABLED_DISABLE_HEADER="---------------------Public Server Shown--------------------"
 PUBLIC_ENABLED_DISABLE_INFO="Do you want your Server Shown Publicly"
 PUBLIC_ENABLED_DISABLE_EXAMPLE_SHOW="Show Server in Public List: 1 "
-PUBLIC_ENABLED_DISABLE_EXAMPLS_LAN_NO_SHOW="Play Server on LAN or Not Listed Publicly: 0"
+PUBLIC_ENABLED_DISABLE_EXAMPLE_LAN_NO_SHOW="Play Server on LAN or Not Listed Publicly: 0"
 PUBLIC_ENABLED_DISABLE_INPUT="Set Public to 1 or 0: "
 
 #line 281-309
@@ -173,7 +173,7 @@ INSTALL_BUILD_ENABLE_VALHEIM_SERVICE="Enabling Valheim Server on start or after 
 #line 424-243
 INSTALL_BUILD_FINISH_THANK_YOU="Check server status by typing systemctl status valheimserver.service
 Thank you for using the script.
-AND A HUGE THANKS TO github: @Lachlanmac, @JamieeLee, @RedKrieg, @bherbruck 
+AND A HUGE THANKS TO github: @Lachlanmac, @JamieeLee, @RedKrieg, @bherbruck
 @xaviablaza, @joaoanes, @amasover, @madmozg, @nicolas-martin, @devdavi and others!
 If your name is missing! Let me know!
 -ZeroBandwidth
@@ -340,7 +340,7 @@ FUNCTION_WRITE_CONFIG_RESTART_SERVICE_INFO="Restarting Valheim Server Service"
 FUNCTION_CHANGE_PUBLIC_DISPLAY_NAME_HEADER="------------------Set New Public Display Name---------------"
 FUNCTION_CHANGE_PUBLIC_DISPLAY_NAME_INFO="Now for Loki, please follow instructions"
 FUNCTION_CHANGE_PUBLIC_DISPLAY_NAME_INFO_1="The Server is required to have a public display name"
-FUNCTION_CHANGE_PUBLIC_DISPLAY_NAME_INFO_2="The Only SPECIAL characters allowed are: spaces, brackets and apostrophes " 
+FUNCTION_CHANGE_PUBLIC_DISPLAY_NAME_INFO_2="The Only SPECIAL characters allowed are: spaces, brackets and apostrophes "
 FUNCTION_CHANGE_PUBLIC_DISPLAY_CURRENT_NAME="Current Public Display Name: "
 FUNCTION_CHANGE_PUBLIC_DISPLAY_EDIT_NAME_INFO="Enter new public server display name: "
 FUNCTION_CHANGE_PUBLIC_DISPLAY_OLD_PUBLIC_NAME="Old Public Display Name: "
@@ -353,9 +353,9 @@ FUNCTION_CHANGE_DEFAULT_SERVER_PORT_HEADER="---------------------Set New Server 
 FUNCTION_CHANGE_DEFAULT_SERVER_PORT_INFO="Now for Loki, please follow instructions"
 FUNCTION_CHANGE_DEFAULT_SERVER_PORT_INFO_1="The Server is required to have a port to operate on"
 FUNCTION_CHANGE_DEFAULT_SERVER_PORT_INFO_2="Do not use SPECIAL characters:"
-FUNCTION_CHANGE_DEFAULT_SERVER_PORT_INFO_3="New assigned port must be greater than 1024:" 
+FUNCTION_CHANGE_DEFAULT_SERVER_PORT_INFO_3="New assigned port must be greater than 1024:"
 FUNCTION_CHANGE_DEFAULT_SERVER_PORT_CURRENT="Current Server Port: "
-FUNCTION_CHANGE_DEFAULT_SERVER_PORT_EDIT_PORT="Enter new Server Port (Default:2456): " 
+FUNCTION_CHANGE_DEFAULT_SERVER_PORT_EDIT_PORT="Enter new Server Port (Default:2456): "
 FUNCTION_CHANGE_DEFAULT_SERVER_PORT_ERROR_CHECK_MSG="Try again, Loki got you or you typed something wrong or your port range is incorrect"
 FUNCTION_CHANGE_DEFAULT_SERVER_PORT_OLD_PORT="Old Server Port: "
 FUNCTION_CHANGE_DEFAULT_SERVER_PORT_NEW_PORT="New Server Port: "
@@ -374,20 +374,20 @@ Don't you have some bees to go check on? "
                                         #DRAW "------------------------------------------------------------"
 FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_HEADER="---------------Set New Server Access Password---------------"
 FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_INFO="Now for Loki, please follow instructions"
-FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_INFO_1="Valheim requires a UNIQUE password 6 characaters or longer"
+FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_INFO_1="Valheim requires a UNIQUE password 6 characters or longer"
 FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_INFO_2="UNIQUE means Password can not match Public and World Names"
 FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_INFO_3="Do not use SPECIAL characters:"
 FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_CURRENT_DISPLAY_NAME="Current Public Display Name:"
 FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_CURRENT_WORLD_NAME="Current World Name:"
 FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_CURRENT_PASS="Current Access Password: "
-FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_INFO_RULES="This password must be 5 Characters or more" 
+FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_INFO_RULES="This password must be 5 Characters or more"
 FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_INFO_RULES_1="At least one number, one uppercase letter and one lowercase letter"
 FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_GOOD="Good Example: Viking12"
 FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_BAD="Bad Example: Vik!"
 FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_ENTER_NEW="Enter Password to Enter your Valheim Server: "
 FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_ERROR_MSG="Password not accepted - Too Short, Special Characters"
 FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_ERROR_MSG_1="I swear to LOKI, you better NOT use Special Characters"
-FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_OLD_PASS="Old Server Access Password:" 
+FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_OLD_PASS="Old Server Access Password:"
 FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_NEW_PASS="New Server Access Password:"
 FUNCTION_CHANGE_SERVER_ACCESS_PASSWORD_CANCEL="Canceled the renaming of Public Valheim Server Display Name - because Loki sucks"
 
@@ -400,7 +400,7 @@ FUNCTION_HEADER_MENU_INFO_VALHEIM_OFFICIAL_BUILD="Valheim Official Build:"
 FUNCTION_HEADER_MENU_INFO_VALHEIM_LOCAL_BUILD="Valheim Server Build:"
 FUNCTION_HEADER_MENU_INFO_SERVER_NAME="Server Name: "
 FUNCTION_HEADER_MENU_INFO_SERVER_PORT="Server Port:"
-FUNCTION_HEADER_MENU_INFO_PUBLIC_LIST="Public Listing:" 
+FUNCTION_HEADER_MENU_INFO_PUBLIC_LIST="Public Listing:"
 FUNCTION_HEADER_MENU_INFO_CURRENT_NJORD_RELEASE="Github Njord Release: "
 FUNCTION_HEADER_MENU_INFO_LOCAL_NJORD_VERSION="Installed Njord Menu: "
 FUNCTION_HEADER_MENU_INFO_GG_ZEROBANDWIDTH="Happy Gaming - ZeroBandwidth"
@@ -456,7 +456,7 @@ FUNCTION_VALHEIM_PLUS_INSTALL_LETS_GO="Let's GO!!!!"
 
 FUNCTION_VALHEIM_PLUS_ENABLE="Enabling Valheim+"
 FUNCTION_VALHEIM_PLUS_RESTARTING="Restarting Valheim Services, so changes can be applied"
-FUNCTION_VALHEIM_PLUS_ENABLED_ACTIVE="Valheim+ is now enabled and Active" 
+FUNCTION_VALHEIM_PLUS_ENABLED_ACTIVE="Valheim+ is now enabled and Active"
 
 FUNCTION_VALHEIM_PLUS_DISABLE="Valheim+ Disable
 FUNCTION_VALHEIM_PLUS_DISABLE_RESTARTING="Restarting Valheim Services, so changes can be applied"
@@ -468,8 +468,8 @@ FUNCTION_VALHEIM_PLUS_UPDATE_UPDATE_FOUND="Update found!"
 FUNCTION_VALHEIM_PLUS_UPDATE_CONTINUE="Do you wish to continue?"
 FUNCTION_VALHEIM_PLUS_UPDATE_BACKING_UP_VPLUS_CONFIG="Making quick backup of valheim_plus.cfg"
 FUNCTION_VALHEIM_PLUS_UPDATE_DOWNLOADING_VPLUS="Grabbing Latest from Valheim Plus and Installing!"
-FUNCTION_VALHEIM_PLUS_UPDATE_RESTARTING_SERVICES="Restarting Services to apply updates" 
-FUNCTION_VALHEIM_PLUS_UPDATE_CANCELED="Canceled the upgrading of Valheim Plus - because Loki sucks" 
+FUNCTION_VALHEIM_PLUS_UPDATE_RESTARTING_SERVICES="Restarting Services to apply updates"
+FUNCTION_VALHEIM_PLUS_UPDATE_CANCELED="Canceled the upgrading of Valheim Plus - because Loki sucks"
 
 FUNCTION_VALHEIM_PLUS_EDIT_VPLUS_CONFIG_SAVE_RESTART="If you made changes, Valheim Services need to be restarted to take effect"
 FUNCTION_VALHEIM_PLUS_EDIT_VPLUS_CONFIG_SAVE_RESTART_1="Do you wish to restart Valheim Services now?"

--- a/menu.sh
+++ b/menu.sh
@@ -282,7 +282,7 @@ echo ""
     tput setaf 1; echo "$PUBLIC_ENABLED_DISABLE_INFO" ; tput setaf 9;
     tput setaf 2; echo "$DRAW60" ; tput setaf 9;
     tput setaf 2; echo "$PUBLIC_ENABLED_DISABLE_EXAMPLE_SHOW" ; tput setaf 9;
-    tput setaf 1; echo "$PUBLIC_ENABLED_DISABLE_EXAMPLS_LAN_NO_SHOW" ; tput setaf 9;
+    tput setaf 1; echo "$PUBLIC_ENABLED_DISABLE_EXAMPLE_LAN_NO_SHOW" ; tput setaf 9;
     tput setaf 2; echo "$DRAW60" ; tput setaf 9;
     echo ""
       read -p "$PUBLIC_ENABLED_DISABLE_INPUT" publicList


### PR DESCRIPTION
Am excited to see multi-lang support (https://github.com/Nimdy/Dedicated_Valheim_Server_Script/issues/199, https://github.com/Nimdy/Dedicated_Valheim_Server_Script/pull/193, https://github.com/Nimdy/Dedicated_Valheim_Server_Script/pull/181)! I am currently writing up a localization update for Galego, and spotted these minor localization config typos to fix. :)

- `PUBLIC_ENABLED_DISABLE_EXAMPLS_LAN_NO_SHOW` to `PUBLIC_ENABLED_DISABLE_EXAMPLE_LAN_NO_SHOW`
- `Mulitpule` to `Multiple`
- `characaters` to `characters`
- a single case of a missing #line prefix before number 177