### PR TITLE
Update firewall install commands

### DIFF
--- a/njordmenu.sh
+++ b/njordmenu.sh
@@ -461,7 +461,7 @@ function valheim_server_install() {
 		if [ "${usefw}" == "y" ] ; then 
 			if [ "${fwbeingused}" == "ufw" ] ; then
 				if command -v ufw >/dev/null; then
-					sudo ufw allow ${portnumber}:${portnumber+2}/udp
+					sudo ufw allow ${portnumber}:${portnumber+2}/udp comment "added by njordmenu"
 					# The above command needs to be validated.
 					echo "Adding ports to the UFW system."
 				fi

--- a/njordmenu.sh
+++ b/njordmenu.sh
@@ -453,7 +453,7 @@ function valheim_server_install() {
 		sleep 1
 	
   
-		#### Need to add code to veriy firewall system and if enabled.
+		#### Need to add code to verify firewall system and if enabled.
 		#### Below is the line needed for Valheim
 		#### These should also be added to as port forwards on your network router.
 		####
@@ -461,13 +461,13 @@ function valheim_server_install() {
 		if [ "${usefw}" == "y" ] ; then 
 			if [ "${fwbeingused}" == "ufw" ] ; then
 				if command -v ufw >/dev/null; then
-					sudo ufw allow ${portnumber}:${portnumber+2}/upd
+					sudo ufw allow ${portnumber}:${portnumber+2}/udp
 					# The above command needs to be validated.
 					echo "Adding ports to the UFW system."
 				fi
 			elif [ "${fwbeingused}" == "iptables" ] ; then
 				if command -v iptables >/dev/null; then
-					# sudo iptables –A INPUT –p upd ––dport ${portnumber},${portnumber}+1,${portnumber}+2) –j ACCEPT
+					# sudo iptables –A INPUT –p udp ––dport ${portnumber},${portnumber}+1,${portnumber}+2) –j ACCEPT
 					#if [ "$ID" == "fedora" ] || [ "$ID "= "centos" ] || [ "$ID" == "ol" ] || [ "$ID" = "rhel" ] )  ; then
 					#	sudo /sbin/service iptables save
 					#else


### PR DESCRIPTION
During a new install, I noticed an error when attempting to configure UFW.  
- This PR fixes the `ufw` command to specify `/udp`
- This PR also specifies `udp` for the `iptables` command
- Adds a comment to the UFW rule stating the rule was added by njordmenu
